### PR TITLE
Fix Langfuse hook cwd fail for Windows

### DIFF
--- a/plugins/tracing/hooks/hooks.json
+++ b/plugins/tracing/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/codex-observability-plugin/tracing/0.1.0/dist/index.mjs\"",
+            "command": "node \"${PLUGIN_ROOT}/dist/index.mjs\"",
             "timeout": 30,
             "statusMessage": "Uploading Codex trace to Langfuse"
           }


### PR DESCRIPTION
## Summary
- fix Langfuse hook working directory handling on Windows
- ensure path/cwd resolution behaves correctly across platforms

## Notes
- source commit: `c19e1b3e3d9e7b10a6501b8a4b487293bc9ced35`