### PR TITLE
Expose Codex service tiers for Langfuse pricing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Once enabled, every Codex turn shows up in Langfuse as a trace you can inspect, 
 After each Codex turn, the plugin reads the session's rollout transcript and uploads it to Langfuse as a [trace](https://langfuse.com/docs/observability/data-model). The structure mirrors how Codex actually works:
 
 - **Turn** (`Codex Turn`, an [agent observation](https://langfuse.com/docs/observability/features/observation-types)) — one trace per turn, from your prompt to the final answer.
-- **Generations** — one per model response within the turn, named `LLM` (or `LLM Subagent` inside subagent threads), with the model recorded on the observation plus reasoning, assistant text, the tool calls it requested, and token usage.
+- **Generations** — one per model response within the turn, named `LLM` (or `LLM Subagent` inside subagent threads), with the model recorded on the observation plus reasoning, assistant text, the tool calls it requested, token usage, and the active Codex service tier.
 - **Tool calls** — shell commands, `apply_patch`, `spawn_agent`, MCP tools, web searches, etc., each with its input, output, and error status. MCP calls are named `server.tool`, and failed commands are flagged as errors.
 - **Subagents** — subagent threads are resolved from their own rollout files and nested under the spawning turn as `Codex Subagent Turn`.
 - **Sessions** — all turns from one Codex session are grouped via the Codex thread id, so you can replay the whole session in Langfuse's [Sessions](https://langfuse.com/docs/observability/features/sessions) view.
@@ -94,6 +94,7 @@ Run a Codex turn, then open your Langfuse project to see the trace.
 | `LANGFUSE_CODEX_TAGS`                                         | No       | —                            | Tags for all traces (JSON array or comma-separated)                  |
 | `LANGFUSE_CODEX_METADATA`                                     | No       | —                            | JSON object of metadata to attach to all traces                      |
 | `LANGFUSE_CODEX_TRACE_SEED`                                   | No       | —                            | Derive deterministic trace ids ([details](#deterministic-trace-ids)) |
+| `LANGFUSE_CODEX_SERVICE_TIER`                                 | No       | Codex configuration          | Override the service-tier fallback when the rollout omits it         |
 | `LANGFUSE_CODEX_MAX_CHARS`                                    | No       | `20000`                      | Truncate inputs/outputs longer than this many characters             |
 | `LANGFUSE_CODEX_DEBUG`                                        | No       | `false`                      | Set to `"true"` for verbose logging to stderr                        |
 | `LANGFUSE_CODEX_FAIL_ON_ERROR`                                | No       | `false`                      | Set to `"true"` to make hook upload errors fail the hook             |
@@ -106,6 +107,20 @@ Run a Codex turn, then open your Langfuse project to see the trace.
 | 🇺🇸 US    | `https://us.cloud.langfuse.com`    |
 | 🇯🇵 Japan | `https://jp.cloud.langfuse.com`    |
 | ⚕️ HIPAA | `https://hipaa.cloud.langfuse.com` |
+
+## Service-tier pricing
+
+Codex service tiers can change model pricing. The plugin reads the active tier from each turn's rollout and records it as `codex.service_tier` generation metadata. For an initial turn whose rollout does not yet contain the tier, it falls back to `service_tier` in Codex's global or project `config.toml`. `LANGFUSE_CODEX_SERVICE_TIER` or `service_tier` in `langfuse.json` can override that fallback.
+
+Non-default tiers also add a numeric usage-detail selector. For example, a `priority` tier emits:
+
+```json
+{
+  "codex_service_tier_priority": 1
+}
+```
+
+This lets a Langfuse custom model select a conditional pricing tier with a rule such as `^codex_service_tier_(fast|priority)$ > 0`. Other Codex tiers use the same `codex_service_tier_<normalized-tier>` convention. The selector has no price itself; the matching Langfuse tier supplies the applicable input, cache-read, and output prices. The plugin does not hard-code provider rates or organization-specific discounts.
 
 ## Deterministic trace ids
 
@@ -159,6 +174,7 @@ The same works from JavaScript with the Langfuse SDK: `await createTraceId(`${se
 | `tags`          | `LANGFUSE_CODEX_TAGS`                                         | —                            | Tags for all traces               |
 | `metadata`      | `LANGFUSE_CODEX_METADATA`                                     | —                            | Metadata object for all traces    |
 | `trace_seed`    | `LANGFUSE_CODEX_TRACE_SEED`                                   | —                            | Deterministic trace-id seed       |
+| `service_tier`  | `LANGFUSE_CODEX_SERVICE_TIER`                                 | Codex configuration          | Service-tier fallback override    |
 | `max_chars`     | `LANGFUSE_CODEX_MAX_CHARS`                                    | `20000`                      | Input/output truncation threshold |
 | `debug`         | `LANGFUSE_CODEX_DEBUG`                                        | `false`                      | Verbose logging                   |
 | `fail_on_error` | `LANGFUSE_CODEX_FAIL_ON_ERROR`                                | `false`                      | Fail the hook on upload errors    |

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -4275,6 +4275,7 @@ const ConfigSchema = object({
 	tags: array(string()).optional(),
 	metadata: record(string(), string()).optional(),
 	trace_seed: string().optional(),
+	service_tier: string().optional(),
 	max_chars: number().int().positive(),
 	debug: boolean(),
 	fail_on_error: boolean()
@@ -4379,6 +4380,18 @@ async function readCodexUserEmail(authFile) {
 		return;
 	}
 }
+async function readCodexServiceTier(configFile) {
+	try {
+		const config$1 = await fs.readFile(configFile, "utf-8");
+		for (const line of config$1.split("\n")) {
+			if (/^\s*\[/.test(line)) break;
+			const match = /^\s*service_tier\s*=\s*["']([^"']+)["']/.exec(line);
+			if (match) return match[1];
+		}
+	} catch {
+		return;
+	}
+}
 function getVar(suffix, env) {
 	return env[`LANGFUSE_CODEX_${suffix}`] ?? env[`LANGFUSE_${suffix}`];
 }
@@ -4393,26 +4406,36 @@ function readEnvConfig(env) {
 		tags: parseTags(env.LANGFUSE_CODEX_TAGS),
 		metadata: parseMetadata(env.LANGFUSE_CODEX_METADATA),
 		trace_seed: env.LANGFUSE_CODEX_TRACE_SEED,
+		service_tier: env.LANGFUSE_CODEX_SERVICE_TIER,
 		max_chars: parseInteger(env.LANGFUSE_CODEX_MAX_CHARS),
 		debug: parseBoolean(env.LANGFUSE_CODEX_DEBUG),
 		fail_on_error: parseBoolean(env.LANGFUSE_CODEX_FAIL_ON_ERROR)
 	}));
 }
 const getHomeDir = () => process.env.HOME ?? os$2.homedir();
+function getCodexHome(home, env) {
+	return env.CODEX_HOME?.trim() || path.join(home, ".codex");
+}
 function getCodexAuthFile(home, env) {
-	const codexHome = env.CODEX_HOME?.trim();
-	return codexHome ? path.join(codexHome, "auth.json") : path.join(home, ".codex", "auth.json");
+	return path.join(getCodexHome(home, env), "auth.json");
 }
 async function getConfig(options) {
 	const home = options?.home ?? getHomeDir();
 	const cwd = options?.cwd ?? process.cwd();
 	const env = options?.env ?? process.env;
-	const [globalConfig$1, localConfig] = await Promise.all([readConfigFile(path.join(home, ".codex", "langfuse.json")), readConfigFile(path.join(cwd, ".codex", "langfuse.json"))]);
+	const [globalConfig$1, localConfig, globalCodexServiceTier, localCodexServiceTier] = await Promise.all([
+		readConfigFile(path.join(home, ".codex", "langfuse.json")),
+		readConfigFile(path.join(cwd, ".codex", "langfuse.json")),
+		readCodexServiceTier(path.join(getCodexHome(home, env), "config.toml")),
+		readCodexServiceTier(path.join(cwd, ".codex", "config.toml"))
+	]);
 	const envConfig = readEnvConfig(env);
 	const codexUserId = globalConfig$1?.user_id ?? localConfig?.user_id ?? envConfig.user_id ? void 0 : await readCodexUserEmail(getCodexAuthFile(home, env));
 	return ConfigSchema.parse({
 		...DEFAULTS,
 		...codexUserId ? { user_id: codexUserId } : {},
+		...globalCodexServiceTier ? { service_tier: globalCodexServiceTier } : {},
+		...localCodexServiceTier ? { service_tier: localCodexServiceTier } : {},
 		...globalConfig$1,
 		...localConfig,
 		...envConfig
@@ -46650,7 +46673,7 @@ function extractToolError(payload) {
 	if (streams) return streams;
 	if (typeof payload.exit_code === "number") return `Exit code: ${payload.exit_code}`;
 }
-function newTurn(startTime) {
+function newTurn(startTime, serviceTier) {
 	return {
 		turnId: void 0,
 		startTime,
@@ -46658,7 +46681,8 @@ function newTurn(startTime) {
 		steps: [],
 		subagentThreadIds: [],
 		completed: false,
-		aborted: false
+		aborted: false,
+		serviceTier
 	};
 }
 /**
@@ -46677,6 +46701,7 @@ function parseSession(lines) {
 	let turn = null;
 	let step = null;
 	let toolCallsById = /* @__PURE__ */ new Map();
+	let lastServiceTier;
 	let lastTimestamp = Date.now();
 	function newStep(startTime) {
 		return {
@@ -46685,7 +46710,7 @@ function parseSession(lines) {
 			toolCalls: []
 		};
 	}
-	const ensureTurn = (ts) => turn ??= newTurn(ts);
+	const ensureTurn = (ts) => turn ??= newTurn(ts, lastServiceTier);
 	const ensureStep = (ts) => step ??= newStep(ts);
 	const closeStep = (ts, usage) => {
 		if (!step) return;
@@ -46724,7 +46749,12 @@ function parseSession(lines) {
 		}
 		if (line.type === "turn_context") {
 			const t = ensureTurn(ts);
-			t.model = line.payload.model ?? t.model;
+			const p = line.payload;
+			t.model = p.model ?? t.model;
+			if (typeof p.service_tier === "string") {
+				lastServiceTier = p.service_tier;
+				t.serviceTier = p.service_tier;
+			}
 			t.invocationParams = line.payload;
 			continue;
 		}
@@ -46810,12 +46840,20 @@ function parseSession(lines) {
 		if (line.type === "event_msg") {
 			const p = line.payload;
 			const et = p.type;
+			if (et === "thread_settings_applied") {
+				const serviceTier = p.thread_settings?.service_tier;
+				if (typeof serviceTier === "string") {
+					lastServiceTier = serviceTier;
+					if (turn) turn.serviceTier = serviceTier;
+				}
+				continue;
+			}
 			if (et === "task_started") {
 				if (turn) finishTurn(ts, {
 					completed: false,
 					aborted: false
 				});
-				turn = newTurn(ts);
+				turn = newTurn(ts, lastServiceTier);
 				turn.turnId = typeof p.turn_id === "string" ? p.turn_id : void 0;
 				continue;
 			}
@@ -46991,6 +47029,11 @@ function toUsageDetails(usage) {
 	if (typeof usage.reasoning_output_tokens === "number") details.reasoning_tokens = usage.reasoning_output_tokens;
 	return Object.keys(details).length > 0 ? details : void 0;
 }
+function serviceTierUsageKey(serviceTier) {
+	const normalized = serviceTier?.trim().toLowerCase().replace(/[^a-z0-9]+/g, "_").replace(/^_+|_+$/g, "");
+	if (!normalized || normalized === "default" || normalized === "standard") return void 0;
+	return `codex_service_tier_${normalized}`;
+}
 /** Build a clip() that truncates long strings to `maxChars`. */
 function makeClip(maxChars) {
 	function clip(value) {
@@ -47046,14 +47089,21 @@ async function emitTurn(turn, sessionMeta, ctx) {
 		parentSpanContext: ctx.parentObservation?.otelSpan.spanContext() ?? ctx.seededParent
 	});
 	let previousToolResults = void 0;
+	const serviceTier = turn.serviceTier ?? ctx.config.service_tier;
+	const tierUsageKey = serviceTierUsageKey(serviceTier);
 	for (let i = 0; i < turn.steps.length; i++) {
 		const step = turn.steps[i];
+		const usageDetails = toUsageDetails(step.usage);
+		if (usageDetails && tierUsageKey && typeof usageDetails.total === "number") usageDetails[tierUsageKey] = 1;
 		const generation = startObservation(isSubagent ? "LLM Subagent" : "LLM", {
 			input: i === 0 ? turn.userInput != null ? clip(turn.userInput) : void 0 : previousToolResults,
 			output: buildGenerationOutput(step, clip),
 			model: turn.model,
-			usageDetails: toUsageDetails(step.usage),
-			metadata: { "codex.step_index": i }
+			usageDetails,
+			metadata: {
+				"codex.step_index": i,
+				...serviceTier ? { "codex.service_tier": serviceTier } : {}
+			}
 		}, {
 			asType: "generation",
 			startTime: new Date(step.startTime),

--- a/plugins/tracing/src/config.ts
+++ b/plugins/tracing/src/config.ts
@@ -33,6 +33,8 @@ export const ConfigSchema = z.object({
   metadata: z.record(z.string(), z.string()).optional(),
   // LANGFUSE_CODEX_TRACE_SEED — deterministic trace ids derived from this seed
   trace_seed: z.string().optional(),
+  // LANGFUSE_CODEX_SERVICE_TIER — fallback when the rollout omits the tier
+  service_tier: z.string().optional(),
   // LANGFUSE_CODEX_MAX_CHARS — truncate large inputs/outputs
   max_chars: z.number().int().positive(),
   // LANGFUSE_CODEX_DEBUG
@@ -171,6 +173,20 @@ async function readCodexUserEmail(authFile: string): Promise<string | undefined>
   }
 }
 
+async function readCodexServiceTier(configFile: string): Promise<string | undefined> {
+  try {
+    const config = await fs.readFile(configFile, "utf-8");
+    for (const line of config.split("\n")) {
+      if (/^\s*\[/.test(line)) break;
+      const match = /^\s*service_tier\s*=\s*["']([^"']+)["']/.exec(line);
+      if (match) return match[1];
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
+}
+
 function getVar(suffix: string, env: Record<string, string | undefined>): string | undefined {
   return env[`LANGFUSE_CODEX_${suffix}`] ?? env[`LANGFUSE_${suffix}`];
 }
@@ -187,6 +203,7 @@ function readEnvConfig(env: Record<string, string | undefined>): Partial<Config>
       tags: parseTags(env.LANGFUSE_CODEX_TAGS),
       metadata: parseMetadata(env.LANGFUSE_CODEX_METADATA),
       trace_seed: env.LANGFUSE_CODEX_TRACE_SEED,
+      service_tier: env.LANGFUSE_CODEX_SERVICE_TIER,
       max_chars: parseInteger(env.LANGFUSE_CODEX_MAX_CHARS),
       debug: parseBoolean(env.LANGFUSE_CODEX_DEBUG),
       fail_on_error: parseBoolean(env.LANGFUSE_CODEX_FAIL_ON_ERROR),
@@ -196,9 +213,12 @@ function readEnvConfig(env: Record<string, string | undefined>): Partial<Config>
 
 const getHomeDir = () => process.env.HOME ?? os.homedir();
 
+function getCodexHome(home: string, env: Record<string, string | undefined>): string {
+  return env.CODEX_HOME?.trim() || path.join(home, ".codex");
+}
+
 function getCodexAuthFile(home: string, env: Record<string, string | undefined>): string {
-  const codexHome = env.CODEX_HOME?.trim();
-  return codexHome ? path.join(codexHome, "auth.json") : path.join(home, ".codex", "auth.json");
+  return path.join(getCodexHome(home, env), "auth.json");
 }
 
 export async function getConfig(options?: {
@@ -210,10 +230,13 @@ export async function getConfig(options?: {
   const cwd = options?.cwd ?? process.cwd();
   const env = options?.env ?? process.env;
 
-  const [globalConfig, localConfig] = await Promise.all([
-    readConfigFile(path.join(home, ".codex", "langfuse.json")),
-    readConfigFile(path.join(cwd, ".codex", "langfuse.json")),
-  ]);
+  const [globalConfig, localConfig, globalCodexServiceTier, localCodexServiceTier] =
+    await Promise.all([
+      readConfigFile(path.join(home, ".codex", "langfuse.json")),
+      readConfigFile(path.join(cwd, ".codex", "langfuse.json")),
+      readCodexServiceTier(path.join(getCodexHome(home, env), "config.toml")),
+      readCodexServiceTier(path.join(cwd, ".codex", "config.toml")),
+    ]);
   const envConfig = readEnvConfig(env);
   const explicitUserId = globalConfig?.user_id ?? localConfig?.user_id ?? envConfig.user_id;
   const codexUserId = explicitUserId
@@ -223,6 +246,8 @@ export async function getConfig(options?: {
   return ConfigSchema.parse({
     ...DEFAULTS,
     ...(codexUserId ? { user_id: codexUserId } : {}),
+    ...(globalCodexServiceTier ? { service_tier: globalCodexServiceTier } : {}),
+    ...(localCodexServiceTier ? { service_tier: localCodexServiceTier } : {}),
     ...globalConfig,
     ...localConfig,
     ...envConfig,

--- a/plugins/tracing/src/parse.ts
+++ b/plugins/tracing/src/parse.ts
@@ -13,6 +13,7 @@ import type {
   TokenUsage,
   ToolCall,
   Turn,
+  TurnContextPayload,
 } from "./types.js";
 import { isPrimitive, toText } from "./utils.js";
 
@@ -84,7 +85,7 @@ function extractToolError(payload: EventMsgPayload): string | undefined {
 /** A turn that is still being assembled. */
 type MutableTurn = Turn & { lastAgentMessage?: string; userInputFallback?: string };
 
-function newTurn(startTime: number): MutableTurn {
+function newTurn(startTime: number, serviceTier: string | undefined): MutableTurn {
   return {
     turnId: undefined,
     startTime,
@@ -93,6 +94,7 @@ function newTurn(startTime: number): MutableTurn {
     subagentThreadIds: [],
     completed: false,
     aborted: false,
+    serviceTier,
   };
 }
 
@@ -116,13 +118,14 @@ export function parseSession(lines: RolloutLine[]): {
   let turn: MutableTurn | null = null;
   let step: ModelStep | null = null;
   let toolCallsById = new Map<string, ToolCall>();
+  let lastServiceTier: string | undefined;
   let lastTimestamp = Date.now();
 
   function newStep(startTime: number): ModelStep {
     return { startTime, endTime: startTime, toolCalls: [] };
   }
 
-  const ensureTurn = (ts: number): MutableTurn => (turn ??= newTurn(ts));
+  const ensureTurn = (ts: number): MutableTurn => (turn ??= newTurn(ts, lastServiceTier));
   const ensureStep = (ts: number) => (step ??= newStep(ts));
 
   const closeStep = (ts: number, usage?: TokenUsage) => {
@@ -175,8 +178,12 @@ export function parseSession(lines: RolloutLine[]): {
 
     if (line.type === "turn_context") {
       const t = ensureTurn(ts);
-      const p = line.payload as { model?: string };
+      const p = line.payload as TurnContextPayload;
       t.model = p.model ?? t.model;
+      if (typeof p.service_tier === "string") {
+        lastServiceTier = p.service_tier;
+        t.serviceTier = p.service_tier;
+      }
       t.invocationParams = line.payload as Record<string, unknown>;
       continue;
     }
@@ -284,9 +291,18 @@ export function parseSession(lines: RolloutLine[]): {
       const p = line.payload as EventMsgPayload;
       const et = p.type;
 
+      if (et === "thread_settings_applied") {
+        const serviceTier = p.thread_settings?.service_tier;
+        if (typeof serviceTier === "string") {
+          lastServiceTier = serviceTier;
+          if (turn) turn.serviceTier = serviceTier;
+        }
+        continue;
+      }
+
       if (et === "task_started") {
         if (turn) finishTurn(ts, { completed: false, aborted: false });
-        turn = newTurn(ts);
+        turn = newTurn(ts, lastServiceTier);
         turn.turnId = typeof p.turn_id === "string" ? p.turn_id : undefined;
         continue;
       }

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -124,6 +124,16 @@ function toUsageDetails(usage: TokenUsage | undefined): Record<string, number> |
   return Object.keys(details).length > 0 ? details : undefined;
 }
 
+function serviceTierUsageKey(serviceTier: string | undefined): string | undefined {
+  const normalized = serviceTier
+    ?.trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "");
+  if (!normalized || normalized === "default" || normalized === "standard") return undefined;
+  return `codex_service_tier_${normalized}`;
+}
+
 type Clip = {
   (value: string): string;
   (value: unknown): unknown;
@@ -210,9 +220,15 @@ async function emitTurn(
   );
 
   let previousToolResults: unknown = undefined;
+  const serviceTier = turn.serviceTier ?? ctx.config.service_tier;
+  const tierUsageKey = serviceTierUsageKey(serviceTier);
 
   for (let i = 0; i < turn.steps.length; i++) {
     const step = turn.steps[i];
+    const usageDetails = toUsageDetails(step.usage);
+    if (usageDetails && tierUsageKey && typeof usageDetails.total === "number") {
+      usageDetails[tierUsageKey] = 1;
+    }
     const generation = startObservation(
       isSubagent ? "LLM Subagent" : "LLM",
       {
@@ -224,8 +240,11 @@ async function emitTurn(
             : previousToolResults,
         output: buildGenerationOutput(step, clip),
         model: turn.model,
-        usageDetails: toUsageDetails(step.usage),
-        metadata: { "codex.step_index": i },
+        usageDetails,
+        metadata: {
+          "codex.step_index": i,
+          ...(serviceTier ? { "codex.service_tier": serviceTier } : {}),
+        },
       },
       {
         asType: "generation",

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -107,6 +107,7 @@ export type ResponseItem =
 
 export type TurnContextPayload = {
   model?: string;
+  service_tier?: string | null;
   [key: string]: unknown;
 };
 
@@ -127,6 +128,11 @@ export type EventMsgPayload = {
     total_token_usage?: TokenUsage;
     last_token_usage?: TokenUsage;
     model_context_window?: number;
+  } | null;
+  /** thread_settings_applied */
+  thread_settings?: {
+    service_tier?: string | null;
+    [key: string]: unknown;
   } | null;
   /** collab_agent_spawn_end */
   new_thread_id?: string | null;
@@ -204,6 +210,7 @@ export type Turn = {
   startTime: number;
   endTime: number;
   model?: string;
+  serviceTier?: string;
   invocationParams?: Record<string, unknown>;
   userInput?: string;
   finalOutput?: string;

--- a/plugins/tracing/test/config.test.ts
+++ b/plugins/tracing/test/config.test.ts
@@ -213,6 +213,28 @@ describe("getConfig", () => {
     expect(fromEnv.trace_seed).toBe("seed-from-env");
   });
 
+  it("uses Codex service-tier config as an overridable rollout fallback", async () => {
+    const home = emptyHome();
+    const cwd = emptyHome();
+    fs.mkdirSync(path.join(home, ".codex"), { recursive: true });
+    fs.mkdirSync(path.join(cwd, ".codex"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, ".codex", "config.toml"),
+      'service_tier = "fast"\n[features]\nfast_mode = true\n',
+    );
+    fs.writeFileSync(path.join(cwd, ".codex", "config.toml"), 'service_tier = "flex"\n');
+
+    const fromCodexConfig = await getConfig({ home, cwd, env: {} });
+    expect(fromCodexConfig.service_tier).toBe("flex");
+
+    const fromEnv = await getConfig({
+      home,
+      cwd,
+      env: { LANGFUSE_CODEX_SERVICE_TIER: "priority" },
+    });
+    expect(fromEnv.service_tier).toBe("priority");
+  });
+
   it("parses fail-on-error from config and environment", async () => {
     const home = makeTmpHome({
       rel: ".codex/langfuse.json",

--- a/plugins/tracing/test/parse.test.ts
+++ b/plugins/tracing/test/parse.test.ts
@@ -81,6 +81,36 @@ describe("parseSession", () => {
     expect(turn.endTime).toBe(Date.parse("2026-06-03T11:00:05.000Z"));
   });
 
+  it("applies service-tier changes to the next turn without creating an empty turn", () => {
+    const lines: RolloutLine[] = [
+      { timestamp: "2026-06-03T12:00:00.000Z", type: "session_meta", payload: { id: "s" } },
+      {
+        timestamp: "2026-06-03T12:00:00.500Z",
+        type: "event_msg",
+        payload: {
+          type: "thread_settings_applied",
+          thread_settings: { service_tier: "priority" },
+        },
+      },
+      {
+        timestamp: "2026-06-03T12:00:01.000Z",
+        type: "event_msg",
+        payload: { type: "task_started", turn_id: "t" },
+      },
+      {
+        timestamp: "2026-06-03T12:00:02.000Z",
+        type: "event_msg",
+        payload: { type: "task_complete", turn_id: "t" },
+      },
+    ];
+
+    const { turns } = parseSession(lines);
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0].turnId).toBe("t");
+    expect(turns[0].serviceTier).toBe("priority");
+  });
+
   it("treats a trailing, never-completed turn as not completed", () => {
     const lines: RolloutLine[] = [
       { timestamp: "2026-06-03T12:00:00.000Z", type: "session_meta", payload: { id: "s" } },

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -172,6 +172,25 @@ describe("convertRollout", () => {
     await convertRollout(file, { config: baseConfig });
     expect(exporter.getFinishedSpans()).toHaveLength(0);
   });
+
+  it("emits service-tier metadata and a generic Langfuse pricing selector", async () => {
+    const dir = stageFixtures();
+    await convertRollout(path.join(dir, "rollout-basic-main.jsonl"), {
+      config: { ...baseConfig, service_tier: "priority" },
+    });
+
+    const generation = exporter
+      .getFinishedSpans()
+      .filter((span) => obsType(span) === "generation")
+      .find((span) => attr(span, "langfuse.observation.usage_details").includes('"total":120'));
+
+    expect(generation).toBeDefined();
+    expect(JSON.parse(attr(generation!, "langfuse.observation.usage_details"))).toMatchObject({
+      total: 120,
+      codex_service_tier_priority: 1,
+    });
+    expect(attr(generation!, "langfuse.observation.metadata.codex.service_tier")).toBe("priority");
+  });
 });
 
 describe("deterministic trace ids (trace_seed)", () => {


### PR DESCRIPTION
## Context

Codex service tiers can change model pricing, but the tracing plugin currently drops the active tier. As a result, Langfuse cannot distinguish Standard, Fast/Priority, Flex, or catalog-defined tiers when inferring cost.

Codex records tier changes in `thread_settings_applied.service_tier`. The first turn of a session may precede that event, so the plugin also needs a configuration fallback. Langfuse pricing-tier conditions operate on numeric usage details, while the raw tier remains useful as metadata.

## What this changes

- captures the per-turn Codex service tier without creating an empty synthetic turn for settings events
- falls back to global/project Codex `config.toml` for an initial turn whose rollout omits the tier
- supports an explicit `service_tier` / `LANGFUSE_CODEX_SERVICE_TIER` fallback override
- records the raw tier as `codex.service_tier` generation metadata
- emits a generic numeric selector for non-default tiers, e.g. `codex_service_tier_priority = 1`
- documents how to use the selector in a Langfuse custom-model pricing condition

The plugin does not hard-code provider prices, credit conversions, or organization-specific discounts. Each Langfuse project remains responsible for its own model rate cards.

## Example

A Fast-mode rollout that reports `service_tier: "priority"` emits:

```json
{
  "metadata": {
    "codex.service_tier": "priority"
  },
  "usageDetails": {
    "codex_service_tier_priority": 1
  }
}
```

A custom model can select its higher-rate tier with a condition such as `^codex_service_tier_(fast|priority)$ > 0`.

## Scope and PR split

This PR is intentionally independent of:

- #28, which normalizes cached-input and reasoning-output usage buckets
- #33, which fixes installed hook path resolution

Those correctness/reliability changes should remain separately reviewable. The generated bundle is included because this repository requires committed build output.

## Validation

- `corepack pnpm@9.5.0 test` — 38 passing
- `corepack pnpm@9.5.0 run lint` — Prettier, TypeScript, and generated-bundle checks pass