### PR TITLE
Preserve the primary hook failure during shutdown

### DIFF
--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -47177,19 +47177,20 @@ async function runHook() {
 		return;
 	}
 	const instrumentation = setupInstrumentation(config$1);
+	let failure;
 	try {
 		await convertRollout(hookInput.transcript_path, { config: config$1 });
 	} catch (error) {
 		debugLog("failed to convert rollout:", error);
-		if (config$1.fail_on_error) throw error;
-	} finally {
-		try {
-			await instrumentation.shutdown();
-		} catch (error) {
-			debugLog("error during flush/shutdown:", error);
-			if (config$1.fail_on_error) throw error;
-		}
+		if (config$1.fail_on_error) failure = error;
 	}
+	try {
+		await instrumentation.shutdown();
+	} catch (error) {
+		debugLog("error during flush/shutdown:", error);
+		if (config$1.fail_on_error && failure === void 0) failure = error;
+	}
+	if (failure !== void 0) throw failure;
 }
 runHook().catch((error) => {
 	if (process.env.LANGFUSE_CODEX_DEBUG === "true") console.error("[langfuse-codex] fatal:", error);

--- a/plugins/tracing/src/index.ts
+++ b/plugins/tracing/src/index.ts
@@ -45,19 +45,20 @@ export async function runHook(): Promise<void> {
   }
 
   const instrumentation = setupInstrumentation(config);
+  let failure: unknown;
   try {
     await convertRollout(hookInput.transcript_path, { config });
   } catch (error) {
     debugLog("failed to convert rollout:", error);
-    if (config.fail_on_error) throw error;
-  } finally {
-    try {
-      await instrumentation.shutdown();
-    } catch (error) {
-      debugLog("error during flush/shutdown:", error);
-      if (config.fail_on_error) throw error;
-    }
+    if (config.fail_on_error) failure = error;
   }
+  try {
+    await instrumentation.shutdown();
+  } catch (error) {
+    debugLog("error during flush/shutdown:", error);
+    if (config.fail_on_error && failure === undefined) failure = error;
+  }
+  if (failure !== undefined) throw failure;
 }
 
 runHook().catch((error) => {

--- a/plugins/tracing/test/index.test.ts
+++ b/plugins/tracing/test/index.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => {
+  const conversionError = new Error("conversion failed");
+  const shutdownError = new Error("shutdown failed");
+  return {
+    conversionError,
+    convertRollout: vi.fn(async () => {
+      throw conversionError;
+    }),
+    shutdown: vi.fn(async () => {
+      throw shutdownError;
+    }),
+  };
+});
+
+vi.mock("../src/config.js", () => ({
+  getConfig: vi.fn(async () => ({
+    enabled: true,
+    public_key: "pk-lf-test",
+    secret_key: "sk-lf-test",
+    base_url: "https://cloud.langfuse.com",
+    max_chars: 20_000,
+    debug: false,
+    fail_on_error: true,
+  })),
+}));
+vi.mock("../src/instrumentation.js", () => ({
+  setupInstrumentation: vi.fn(() => ({ shutdown: mocks.shutdown })),
+}));
+vi.mock("../src/trace.js", () => ({ convertRollout: mocks.convertRollout }));
+vi.mock("../src/utils.js", () => ({
+  debugLog: vi.fn(),
+  readStdin: vi.fn(async () => ({ transcript_path: "/tmp/rollout.jsonl" })),
+  setDebug: vi.fn(),
+}));
+
+let runHook: () => Promise<void>;
+
+beforeAll(async () => {
+  ({ runHook } = await import("../src/index.js"));
+  await vi.waitFor(() => expect(mocks.shutdown).toHaveBeenCalled());
+});
+
+afterEach(() => {
+  process.exitCode = undefined;
+});
+
+describe("runHook", () => {
+  it("preserves the conversion error when shutdown also fails", async () => {
+    await expect(runHook()).rejects.toBe(mocks.conversionError);
+  });
+});


### PR DESCRIPTION
## Problem

With `fail_on_error=true`, a rollout-conversion failure is thrown from the hook's `try` block. If telemetry shutdown then also fails in `finally`, the shutdown error replaces the original conversion error, hiding the root cause.

## Change

Capture both failures while still always attempting shutdown, then rethrow the conversion failure first. A shutdown-only failure continues to propagate, and the default fail-open behavior is unchanged.

This is intentionally separate from usage accounting (#28), hook path portability (#33), and service-tier pricing (#34).

## Validation

- `corepack pnpm@9.5.0 test` — 36 passing
- `corepack pnpm@9.5.0 run lint` — Prettier, TypeScript, and generated-bundle checks pass