### PR TITLE
fix: support sub_agent_activity events when resolving subagent traces

### DIFF
--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -46687,6 +46687,9 @@ function parseSession(lines) {
 	}
 	const ensureTurn = (ts) => turn ??= newTurn(ts);
 	const ensureStep = (ts) => step ??= newStep(ts);
+	const recordSubagentThread = (threadId) => {
+		if (!turn.subagentThreadIds.includes(threadId)) turn.subagentThreadIds.push(threadId);
+	};
 	const closeStep = (ts, usage) => {
 		if (!step) return;
 		step.endTime = Math.max(step.endTime, ts);
@@ -46835,7 +46838,8 @@ function parseSession(lines) {
 				aborted: true
 			});
 			else {
-				if (et === "collab_agent_spawn_end" && typeof p.new_thread_id === "string") turn.subagentThreadIds.push(p.new_thread_id);
+				if (et === "collab_agent_spawn_end" && typeof p.new_thread_id === "string") recordSubagentThread(p.new_thread_id);
+				if (et === "sub_agent_activity" && p.kind === "started" && typeof p.agent_thread_id === "string") recordSubagentThread(p.agent_thread_id);
 				if ((et === "mcp_tool_call_begin" || et === "mcp_tool_call_end") && typeof p.call_id === "string") {
 					const tc = toolCallsById.get(p.call_id);
 					const inv = p.invocation;

--- a/plugins/tracing/src/parse.ts
+++ b/plugins/tracing/src/parse.ts
@@ -125,6 +125,14 @@ export function parseSession(lines: RolloutLine[]): {
   const ensureTurn = (ts: number): MutableTurn => (turn ??= newTurn(ts));
   const ensureStep = (ts: number) => (step ??= newStep(ts));
 
+  // Rollouts from the transition period can carry both spawn-event formats
+  // for the same child; the thread must be nested exactly once.
+  const recordSubagentThread = (threadId: string) => {
+    if (!turn!.subagentThreadIds.includes(threadId)) {
+      turn!.subagentThreadIds.push(threadId);
+    }
+  };
+
   const closeStep = (ts: number, usage?: TokenUsage) => {
     if (!step) return;
     step.endTime = Math.max(step.endTime, ts);
@@ -308,7 +316,18 @@ export function parseSession(lines: RolloutLine[]): {
         // A subagent spawn records the child thread *and* (since it carries a
         // call_id ending in "_end") enriches the spawning tool call below.
         if (et === "collab_agent_spawn_end" && typeof p.new_thread_id === "string") {
-          turn!.subagentThreadIds.push(p.new_thread_id);
+          recordSubagentThread(p.new_thread_id);
+        }
+        // Codex multi-agent v2 persists the spawn as sub_agent_activity
+        // instead. Only kind "started" marks a spawn — "interacted" and
+        // "interrupted" reference an existing child and would nest it under
+        // the wrong (later) turn.
+        if (
+          et === "sub_agent_activity" &&
+          p.kind === "started" &&
+          typeof p.agent_thread_id === "string"
+        ) {
+          recordSubagentThread(p.agent_thread_id);
         }
         // MCP tool calls are function calls with a mangled name
         // (`server__tool`); the begin/end events carry the clean server/tool

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -131,6 +131,9 @@ export type EventMsgPayload = {
   } | null;
   /** collab_agent_spawn_end */
   new_thread_id?: string | null;
+  /** sub_agent_activity */
+  kind?: string;
+  agent_thread_id?: string | null;
   /** mcp_tool_call_begin / mcp_tool_call_end */
   invocation?: { server?: string; tool?: string; arguments?: unknown } | null;
   /** web_search_end */

--- a/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-activity-main.jsonl
+++ b/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-activity-main.jsonl
@@ -1,0 +1,11 @@
+{"timestamp":"2026-06-03T12:00:00.000Z","type":"session_meta","payload":{"id":"sess-activity","cli_version":"0.145.0","model_provider":"openai"}}
+{"timestamp":"2026-06-03T12:00:01.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-activity"}}
+{"timestamp":"2026-06-03T12:00:01.200Z","type":"turn_context","payload":{"model":"gpt-5.4"}}
+{"timestamp":"2026-06-03T12:00:01.300Z","type":"event_msg","payload":{"type":"user_message","message":"Spawn a worker to compute the answer"}}
+{"timestamp":"2026-06-03T12:00:02.000Z","type":"response_item","payload":{"type":"function_call","name":"spawn_agent","call_id":"call-spawn-act","arguments":"{\"message\":\"compute the answer\"}"}}
+{"timestamp":"2026-06-03T12:00:02.500Z","type":"event_msg","payload":{"type":"sub_agent_activity","event_id":"call-spawn-act","occurred_at_ms":1780488002500,"agent_thread_id":"thread-act","agent_path":"/root/worker","kind":"started"}}
+{"timestamp":"2026-06-03T12:00:02.600Z","type":"event_msg","payload":{"type":"sub_agent_activity","event_id":"call-wait-act","occurred_at_ms":1780488002600,"agent_thread_id":"thread-act","agent_path":"/root/worker","kind":"interacted"}}
+{"timestamp":"2026-06-03T12:00:02.800Z","type":"response_item","payload":{"type":"function_call_output","call_id":"call-spawn-act","output":"{\"agent_id\":\"thread-act\",\"nickname\":\"Worker\"}"}}
+{"timestamp":"2026-06-03T12:00:04.500Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"The worker replied: 42"}]}}
+{"timestamp":"2026-06-03T12:00:04.600Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"output_tokens":20,"total_tokens":120,"cached_input_tokens":0,"reasoning_output_tokens":0},"total_token_usage":{"input_tokens":100,"output_tokens":20,"total_tokens":120,"cached_input_tokens":0,"reasoning_output_tokens":0}}}}
+{"timestamp":"2026-06-03T12:00:05.000Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-activity"}}

--- a/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-child-thread-act.jsonl
+++ b/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-child-thread-act.jsonl
@@ -1,0 +1,8 @@
+{"timestamp":"2026-06-03T12:00:03.000Z","type":"session_meta","payload":{"id":"thread-act","cli_version":"0.145.0","model_provider":"openai","parent_thread_id":"sess-activity","thread_source":"subagent"}}
+{"timestamp":"2026-06-03T12:00:03.100Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-act-child"}}
+{"timestamp":"2026-06-03T12:00:03.200Z","type":"turn_context","payload":{"model":"gpt-5.4"}}
+{"timestamp":"2026-06-03T12:00:03.300Z","type":"event_msg","payload":{"type":"user_message","message":"compute the answer"}}
+{"timestamp":"2026-06-03T12:00:04.000Z","type":"response_item","payload":{"type":"message","role":"assistant","content":[{"type":"output_text","text":"42"}]}}
+{"timestamp":"2026-06-03T12:00:04.100Z","type":"event_msg","payload":{"type":"agent_message","message":"42"}}
+{"timestamp":"2026-06-03T12:00:04.200Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":40,"output_tokens":15,"total_tokens":55,"cached_input_tokens":0,"reasoning_output_tokens":0},"total_token_usage":{"input_tokens":40,"output_tokens":15,"total_tokens":55,"cached_input_tokens":0,"reasoning_output_tokens":0}}}}
+{"timestamp":"2026-06-03T12:00:04.300Z","type":"event_msg","payload":{"type":"task_complete","turn_id":"turn-act-child"}}

--- a/plugins/tracing/test/parse.test.ts
+++ b/plugins/tracing/test/parse.test.ts
@@ -69,8 +69,6 @@ describe("parseSession", () => {
     expect(turn.completed).toBe(true);
     expect(turn.aborted).toBe(true);
     expect(turn.userInput).toBe("Spawn a subagent to tell a joke");
-
-    // The spawn is recorded as a subagent thread...
     expect(turn.subagentThreadIds).toEqual(["thread-child"]);
 
     // ...and the failing exec is captured with its error.
@@ -79,6 +77,57 @@ describe("parseSession", () => {
     expect(failing?.error).toBe("command failed");
     expect(turn.startTime).toBe(Date.parse("2026-06-03T11:00:01.000Z"));
     expect(turn.endTime).toBe(Date.parse("2026-06-03T11:00:05.000Z"));
+  });
+
+  it("records subagent threads from sub_agent_activity, ignoring non-started kinds", () => {
+    const event = (ts: string, payload: Record<string, unknown>): RolloutLine => ({
+      timestamp: ts,
+      type: "event_msg",
+      payload: { ...payload },
+    });
+    const lines: RolloutLine[] = [
+      { timestamp: "2026-06-03T13:00:00.000Z", type: "session_meta", payload: { id: "s" } },
+      event("2026-06-03T13:00:01.000Z", { type: "task_started", turn_id: "t" }),
+      event("2026-06-03T13:00:02.000Z", {
+        type: "sub_agent_activity",
+        event_id: "c1",
+        agent_thread_id: "thread-a",
+        agent_path: "/root/worker",
+        kind: "started",
+      }),
+      // The same spawn reported again — legacy format and a repeated activity.
+      event("2026-06-03T13:00:02.100Z", {
+        type: "collab_agent_spawn_end",
+        call_id: "c1",
+        new_thread_id: "thread-a",
+      }),
+      event("2026-06-03T13:00:02.200Z", {
+        type: "sub_agent_activity",
+        event_id: "c1",
+        agent_thread_id: "thread-a",
+        agent_path: "/root/worker",
+        kind: "started",
+      }),
+      // Later lifecycle kinds reference an existing child and must not register.
+      event("2026-06-03T13:00:03.000Z", {
+        type: "sub_agent_activity",
+        event_id: "c2",
+        agent_thread_id: "thread-b",
+        agent_path: "/root/other",
+        kind: "interacted",
+      }),
+      event("2026-06-03T13:00:03.100Z", {
+        type: "sub_agent_activity",
+        event_id: "c3",
+        agent_thread_id: "thread-c",
+        agent_path: "/root/other",
+        kind: "interrupted",
+      }),
+      event("2026-06-03T13:00:04.000Z", { type: "task_complete", turn_id: "t" }),
+    ];
+    const { turns } = parseSession(lines);
+    expect(turns).toHaveLength(1);
+    expect(turns[0].subagentThreadIds).toEqual(["thread-a"]);
   });
 
   it("treats a trailing, never-completed turn as not completed", () => {

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -159,6 +159,30 @@ describe("convertRollout", () => {
     expect(attr(failedTool!, "langfuse.observation.status_message")).toContain("command failed");
   });
 
+  it("nests subagent turns discovered via sub_agent_activity events", async () => {
+    const dir = stageFixtures();
+    await convertRollout(path.join(dir, "rollout-activity-main.jsonl"), { config: baseConfig });
+
+    const spans = exporter.getFinishedSpans();
+    const parent = spans.find((s) => s.name === "Codex Turn" && obsType(s) === "agent");
+    const childTurns = spans.filter(
+      (s) => s.name === "Codex Subagent Turn" && obsType(s) === "agent",
+    );
+    expect(parent).toBeDefined();
+    // Exactly one child (the kind filter itself is pinned at parse level,
+    // where non-"started" activities target distinct thread ids).
+    expect(childTurns).toHaveLength(1);
+    const child = childTurns[0];
+    expect(child.spanContext().traceId).toBe(parent!.spanContext().traceId);
+    expect(attr(child, "langfuse.observation.input")).toContain("compute the answer");
+
+    const childGeneration = spans.find(
+      (s) => obsType(s) === "generation" && parentId(s) === child.spanContext().spanId,
+    );
+    expect(childGeneration?.name).toBe("LLM Subagent");
+    expect(attr(childGeneration!, "langfuse.observation.model.name")).toBe("gpt-5.4");
+  });
+
   it("captures web search, local shell, and MCP tool calls with specific names", async () => {
     const dir = stageFixtures();
     await convertRollout(path.join(dir, "rollout-tools-main.jsonl"), { config: baseConfig });


### PR DESCRIPTION
## Problem

New versions of Codex do not write `collab_agent_spawn_end` events to rollout files ([openai/codex#25712](<https://github.com/openai/codex/issues/25712>)).<br>Multi-agent v2 rollouts use `sub_agent_activity` events instead. The parser does not know this event.<br>Because of this, it does not find the subagent threads. The exported traces do not show the subagent<br>turns or their token usage.

## Fix

The parser now reads both event formats. A shared helper records each thread one time only.<br>This is necessary because one rollout can contain the same spawn in both formats.

The parser accepts only events with `kind: "started"`. The other kinds point to a child that<br>already exists. They would attach the child to the wrong turn.

We compared the event shape with the upstream source code and with a real rollout from Codex 0.147.<br>The test fixtures use the same shape.

## Verification

* All 38 tests pass. The typecheck and `lint:dist` pass. Each commit is green on its own.
* New tests cover: v2 discovery end to end, both event orders, ignored kinds, legacy-only<br>rollouts, and the label fallback.
* Live test: we sent one real v2 rollout through the old hook and through this branch. The old<br>hook shows no subagent. This branch shows `Subagent: pong_agent` with correct usage and cost.

## Not in this PR

* Paginated history mode stores the spawn as a TurnItem. The plugin does not support paginated<br>rollouts. This needs its own issue.
* Default interactive sessions (v1) write no spawn events at all. Discovery through the<br>`agent_id` in the `spawn_agent` tool output is a separate task ([LFE-14827](https://linear.app/clickhouse/issue/LFE-14827/codex-plugin-subagent-llm-usage-missing-in-langfuse-undercount-codex)).

Closes langfuse/codex-observability-plugin#41. Linear: langfuse/codex-observability-plugin#41.