### PR TITLE
fix: prevent duplicate turn uploads

### DIFF
--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -46892,8 +46892,7 @@ function parseSession(lines) {
 * The `Stop` hook fires after every Codex turn and re-reads the whole rollout
 * file, so completed turns would be re-uploaded each time. We record uploaded
 * turn ids in a sidecar file (`<rolloutFile>.langfuse`) and skip them on
-* subsequent invocations. In-progress (not-yet-completed) turns are uploaded
-* but intentionally not recorded, so they finalize on the next hook run.
+* subsequent invocations.
 */
 async function loadUploadedTurnIds(rolloutFile) {
 	try {
@@ -46908,6 +46907,28 @@ async function markTurnUploaded(rolloutFile, turnId) {
 	try {
 		await fs.appendFile(`${rolloutFile}.langfuse`, `${turnId}\n`, "utf-8");
 	} catch {}
+}
+async function claimRolloutUpload(rolloutFile) {
+	const lockFile = `${rolloutFile}.langfuse.lock`;
+	let lock;
+	try {
+		lock = await fs.open(lockFile, "wx");
+	} catch (error) {
+		if (error.code !== "EEXIST") throw error;
+		try {
+			const stat = await fs.stat(lockFile);
+			if (Date.now() - stat.mtimeMs <= 6e4) return void 0;
+			await fs.unlink(lockFile);
+			return claimRolloutUpload(rolloutFile);
+		} catch (lockError) {
+			if (lockError.code === "ENOENT") return claimRolloutUpload(rolloutFile);
+			throw lockError;
+		}
+	}
+	return async () => {
+		await lock.close();
+		await fs.unlink(lockFile).catch(() => void 0);
+	};
 }
 
 //#endregion
@@ -47121,6 +47142,15 @@ function emitToolCall(tc, parent, clip, fallbackEnd) {
 * turn via `parentObservation`.
 */
 async function convertRollout(rolloutFile, options) {
+	const releaseUpload = options.parentObservation ? void 0 : await claimRolloutUpload(rolloutFile);
+	if (!options.parentObservation && !releaseUpload) return;
+	try {
+		await convertClaimedRollout(rolloutFile, options);
+	} finally {
+		await releaseUpload?.();
+	}
+}
+async function convertClaimedRollout(rolloutFile, options) {
 	const { sessionMeta, turns } = parseSession(await loadSession(rolloutFile));
 	debugLog(`parsed ${turns.length} turn(s) from ${path.basename(rolloutFile)}`);
 	if (options.parentObservation) {
@@ -47134,7 +47164,11 @@ async function convertRollout(rolloutFile, options) {
 	const uploaded = await loadUploadedTurnIds(rolloutFile);
 	for (let turnIndex = 0; turnIndex < turns.length; turnIndex++) {
 		const turn = turns[turnIndex];
-		if (turn.completed && turn.turnId && uploaded.has(turn.turnId)) continue;
+		if (!turn.completed) {
+			debugLog(`waiting for in-progress turn ${turn.turnId ?? turnIndex + 1} to complete`);
+			continue;
+		}
+		if (turn.turnId && uploaded.has(turn.turnId)) continue;
 		const seededParent = await seededTraceParent(options.config, sessionMeta, turnIndex + 1);
 		await propagateAttributes({
 			sessionId: sessionMeta.sessionId,
@@ -47149,10 +47183,10 @@ async function convertRollout(rolloutFile, options) {
 				seededParent
 			});
 		});
-		if (turn.completed && turn.turnId) {
+		if (turn.turnId) {
 			uploaded.add(turn.turnId);
 			await markTurnUploaded(rolloutFile, turn.turnId);
-		} else if (turn.turnId) debugLog(`uploaded in-progress turn ${turn.turnId}; waiting for completion before sidecar mark`);
+		}
 	}
 }
 

--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -46718,6 +46718,9 @@ function parseSession(lines) {
 			const p = line.payload;
 			sessionMeta = {
 				sessionId: typeof p.id === "string" ? p.id : sessionMeta.sessionId,
+				cwd: p.cwd,
+				gitBranch: p.git?.branch ?? void 0,
+				gitRepository: p.git?.repository_url ?? void 0,
 				cliVersion: p.cli_version,
 				modelProvider: p.model_provider ?? void 0,
 				baseInstructions: p.base_instructions?.text,
@@ -47072,6 +47075,10 @@ async function emitTurn(turn, sessionMeta, ctx) {
 		metadata: {
 			"codex.turn_id": turn.turnId,
 			"codex.thread_id": sessionMeta.sessionId,
+			project: sessionMeta.cwd ? path.basename(sessionMeta.cwd) : void 0,
+			cwd: sessionMeta.cwd,
+			git_branch: sessionMeta.gitBranch,
+			git_repository: sessionMeta.gitRepository,
 			"codex.model": turn.model,
 			"codex.model_provider": sessionMeta.modelProvider,
 			"codex.cli_version": sessionMeta.cliVersion,

--- a/plugins/tracing/src/parse.ts
+++ b/plugins/tracing/src/parse.ts
@@ -167,12 +167,17 @@ export function parseSession(lines: RolloutLine[]): {
         id?: string;
         cli_version?: string;
         model_provider?: string | null;
+        cwd?: string;
+        git?: { branch?: string | null; repository_url?: string | null } | null;
         base_instructions?: { text?: string } | null;
         parent_thread_id?: string | null;
         thread_source?: string | null;
       };
       sessionMeta = {
         sessionId: typeof p.id === "string" ? p.id : sessionMeta.sessionId,
+        cwd: p.cwd,
+        gitBranch: p.git?.branch ?? undefined,
+        gitRepository: p.git?.repository_url ?? undefined,
         cliVersion: p.cli_version,
         modelProvider: p.model_provider ?? undefined,
         baseInstructions: p.base_instructions?.text,

--- a/plugins/tracing/src/sidecar.ts
+++ b/plugins/tracing/src/sidecar.ts
@@ -6,8 +6,7 @@ import * as fs from "node:fs/promises";
  * The `Stop` hook fires after every Codex turn and re-reads the whole rollout
  * file, so completed turns would be re-uploaded each time. We record uploaded
  * turn ids in a sidecar file (`<rolloutFile>.langfuse`) and skip them on
- * subsequent invocations. In-progress (not-yet-completed) turns are uploaded
- * but intentionally not recorded, so they finalize on the next hook run.
+ * subsequent invocations.
  */
 export async function loadUploadedTurnIds(rolloutFile: string): Promise<Set<string>> {
   try {
@@ -25,4 +24,32 @@ export async function markTurnUploaded(rolloutFile: string, turnId: string): Pro
   } catch {
     // Best-effort: a failed write only risks a duplicate upload next time.
   }
+}
+
+export async function claimRolloutUpload(
+  rolloutFile: string,
+): Promise<(() => Promise<void>) | undefined> {
+  const lockFile = `${rolloutFile}.langfuse.lock`;
+  let lock: fs.FileHandle;
+  try {
+    lock = await fs.open(lockFile, "wx");
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+    try {
+      const stat = await fs.stat(lockFile);
+      if (Date.now() - stat.mtimeMs <= 60_000) return undefined;
+      await fs.unlink(lockFile);
+      return claimRolloutUpload(rolloutFile);
+    } catch (lockError) {
+      if ((lockError as NodeJS.ErrnoException).code === "ENOENT") {
+        return claimRolloutUpload(rolloutFile);
+      }
+      throw lockError;
+    }
+  }
+
+  return async () => {
+    await lock.close();
+    await fs.unlink(lockFile).catch(() => undefined);
+  };
 }

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -228,6 +228,10 @@ async function emitTurn(
       metadata: {
         "codex.turn_id": turn.turnId,
         "codex.thread_id": sessionMeta.sessionId,
+        project: sessionMeta.cwd ? path.basename(sessionMeta.cwd) : undefined,
+        cwd: sessionMeta.cwd,
+        git_branch: sessionMeta.gitBranch,
+        git_repository: sessionMeta.gitRepository,
         "codex.model": turn.model,
         "codex.model_provider": sessionMeta.modelProvider,
         "codex.cli_version": sessionMeta.cliVersion,

--- a/plugins/tracing/src/trace.ts
+++ b/plugins/tracing/src/trace.ts
@@ -13,7 +13,7 @@ import { TraceFlags, type SpanContext } from "@opentelemetry/api";
 
 import type { Config } from "./config.js";
 import { parseSession } from "./parse.js";
-import { loadUploadedTurnIds, markTurnUploaded } from "./sidecar.js";
+import { claimRolloutUpload, loadUploadedTurnIds, markTurnUploaded } from "./sidecar.js";
 import type { ModelStep, RolloutLine, SessionMeta, TokenUsage, ToolCall, Turn } from "./types.js";
 import { debugLog, toText, truncate } from "./utils.js";
 
@@ -331,6 +331,22 @@ export async function convertRollout(
   rolloutFile: string,
   options: { config: Config; parentObservation?: LangfuseObservation },
 ): Promise<void> {
+  const releaseUpload = options.parentObservation
+    ? undefined
+    : await claimRolloutUpload(rolloutFile);
+  if (!options.parentObservation && !releaseUpload) return;
+
+  try {
+    await convertClaimedRollout(rolloutFile, options);
+  } finally {
+    await releaseUpload?.();
+  }
+}
+
+async function convertClaimedRollout(
+  rolloutFile: string,
+  options: { config: Config; parentObservation?: LangfuseObservation },
+): Promise<void> {
   const { sessionMeta, turns } = parseSession(await loadSession(rolloutFile));
   debugLog(`parsed ${turns.length} turn(s) from ${path.basename(rolloutFile)}`);
 
@@ -350,7 +366,11 @@ export async function convertRollout(
 
   for (let turnIndex = 0; turnIndex < turns.length; turnIndex++) {
     const turn = turns[turnIndex];
-    if (turn.completed && turn.turnId && uploaded.has(turn.turnId)) {
+    if (!turn.completed) {
+      debugLog(`waiting for in-progress turn ${turn.turnId ?? turnIndex + 1} to complete`);
+      continue;
+    }
+    if (turn.turnId && uploaded.has(turn.turnId)) {
       continue; // already uploaded in a previous hook invocation
     }
 
@@ -375,15 +395,9 @@ export async function convertRollout(
       },
     );
 
-    // Only mark completed turns as uploaded; an in-progress trailing turn is
-    // re-uploaded (and finalized) on the next hook invocation.
-    if (turn.completed && turn.turnId) {
+    if (turn.turnId) {
       uploaded.add(turn.turnId);
       await markTurnUploaded(rolloutFile, turn.turnId);
-    } else if (turn.turnId) {
-      debugLog(
-        `uploaded in-progress turn ${turn.turnId}; waiting for completion before sidecar mark`,
-      );
     }
   }
 }

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -168,6 +168,9 @@ export type HookInput = {
 /** Resolved session-level metadata. */
 export type SessionMeta = {
   sessionId: string;
+  cwd?: string;
+  gitBranch?: string;
+  gitRepository?: string;
   cliVersion?: string;
   modelProvider?: string;
   baseInstructions?: string;

--- a/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-basic-main.jsonl
+++ b/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-basic-main.jsonl
@@ -1,4 +1,4 @@
-{"timestamp":"2026-06-03T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-basic","cli_version":"0.123.0","model_provider":"openai","base_instructions":{"text":"You are Codex."}}}
+{"timestamp":"2026-06-03T10:00:00.000Z","type":"session_meta","payload":{"id":"sess-basic","cwd":"/repo/workspace","git":{"branch":"feature/test","repository_url":"git@github.com:example/workspace.git"},"cli_version":"0.123.0","model_provider":"openai","base_instructions":{"text":"You are Codex."}}}
 {"timestamp":"2026-06-03T10:00:01.000Z","type":"event_msg","payload":{"type":"task_started","turn_id":"turn-1"}}
 {"timestamp":"2026-06-03T10:00:01.100Z","type":"response_item","payload":{"type":"message","role":"developer","content":[{"type":"input_text","text":"<environment_context>cwd=/repo</environment_context>"}]}}
 {"timestamp":"2026-06-03T10:00:01.200Z","type":"turn_context","payload":{"model":"gpt-5.4","effort":"medium"}}

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -79,6 +79,9 @@ describe("convertRollout", () => {
     expect(parentId(root!)).toBeUndefined(); // top-level turn = its own trace
     expect(attr(root!, "langfuse.observation.input")).toContain("List the files");
     expect(attr(root!, "langfuse.observation.output")).toContain("two files");
+    expect(attr(root!, "langfuse.observation.metadata.project")).toBe("workspace");
+    expect(attr(root!, "langfuse.observation.metadata.cwd")).toBe("/repo/workspace");
+    expect(attr(root!, "langfuse.observation.metadata.git_branch")).toBe("feature/test");
 
     // Backdated to the turn's task_started timestamp.
     expect(startMs(root!)).toBe(Date.parse("2026-06-03T10:00:01.000Z"));

--- a/plugins/tracing/test/trace.test.ts
+++ b/plugins/tracing/test/trace.test.ts
@@ -215,6 +215,35 @@ describe("convertRollout", () => {
     await convertRollout(file, { config: baseConfig });
     expect(exporter.getFinishedSpans()).toHaveLength(0);
   });
+
+  it("waits for an in-progress turn instead of uploading it twice", async () => {
+    const dir = stageFixtures();
+    const file = path.join(dir, "rollout-basic-main.jsonl");
+    const completed = fs.readFileSync(file, "utf-8");
+    fs.writeFileSync(file, completed.replace(/^.*"task_complete".*\n?$/m, ""));
+
+    await convertRollout(file, { config: baseConfig });
+    expect(exporter.getFinishedSpans()).toHaveLength(0);
+    expect(fs.existsSync(`${file}.langfuse`)).toBe(false);
+
+    fs.writeFileSync(file, completed);
+    await convertRollout(file, { config: baseConfig });
+    expect(exporter.getFinishedSpans().some((span) => span.name === "Codex Turn")).toBe(true);
+  });
+
+  it("serializes concurrent uploads of the same rollout", async () => {
+    const dir = stageFixtures();
+    const file = path.join(dir, "rollout-basic-main.jsonl");
+
+    await Promise.all([
+      convertRollout(file, { config: baseConfig }),
+      convertRollout(file, { config: baseConfig }),
+    ]);
+
+    expect(exporter.getFinishedSpans().filter((span) => span.name === "Codex Turn")).toHaveLength(
+      1,
+    );
+  });
 });
 
 describe("deterministic trace ids (trace_seed)", () => {


### PR DESCRIPTION
## Problem
The Stop hook uploads a trailing in-progress turn without recording it in the sidecar. A later hook uploads the completed turn under a new trace ID, which duplicates usage. Concurrent Stop hooks can also race past the sidecar.

## Fix
- wait until a turn has a task_complete or turn_aborted event
- serialize top-level uploads per rollout with a short-lived atomic lock
- recover locks older than the hook timeout

Explicitly interrupted turns remain eligible because turn_aborted marks them completed.

## Verification
- 39 tests pass
- formatting and TypeScript checks pass
- committed bundle reproduces cleanly