### PR TITLE
fix: bind the Langfuse tracer provider so spans always reach the exporter

### DIFF
--- a/plugins/tracing/src/instrumentation.ts
+++ b/plugins/tracing/src/instrumentation.ts
@@ -1,4 +1,5 @@
 import { LangfuseSpanProcessor } from "@langfuse/otel";
+import { setLangfuseTracerProvider } from "@langfuse/tracing";
 import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node";
 
 import type { Config } from "./config.js";
@@ -37,10 +38,14 @@ export function setupInstrumentation(config: Config): Instrumentation {
   });
   provider.register();
 
+  // Bind explicitly: the global registry can refuse the registration silently.
+  setLangfuseTracerProvider(provider);
+
   return {
     shutdown: async () => {
       await spanProcessor.forceFlush();
       await provider.shutdown();
+      setLangfuseTracerProvider(null);
     },
   };
 }

--- a/plugins/tracing/test/instrumentation.test.ts
+++ b/plugins/tracing/test/instrumentation.test.ts
@@ -1,0 +1,103 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { getLangfuseTracerProvider, setLangfuseTracerProvider } from "@langfuse/tracing";
+import type { ReadableSpan, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Config } from "../src/config.js";
+import { setupInstrumentation } from "../src/instrumentation.js";
+import { convertRollout } from "../src/trace.js";
+
+// Capture the spans the plugin's own span processor receives, so the assertion
+// needs no network and no Langfuse credentials.
+const captured: ReadableSpan[] = [];
+
+vi.mock("@langfuse/otel", () => ({
+  LangfuseSpanProcessor: class implements SpanProcessor {
+    onStart(): void {}
+    onEnd(span: ReadableSpan): void {
+      captured.push(span);
+    }
+    async forceFlush(): Promise<void> {}
+    async shutdown(): Promise<void> {}
+  },
+}));
+
+const OTEL_API_KEY = Symbol.for("opentelemetry.js.api.1");
+
+const baseConfig: Config = {
+  enabled: true,
+  public_key: "pk-lf-test",
+  secret_key: "sk-lf-test",
+  base_url: "https://cloud.langfuse.com",
+  max_chars: 20_000,
+  debug: false,
+  fail_on_error: false,
+};
+
+const fixturesRoot = path.join(path.dirname(fileURLToPath(import.meta.url)), "fixtures/sessions");
+
+function stageFixtures(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "lf-codex-instr-"));
+  fs.cpSync(fixturesRoot, path.join(dir, "sessions"), { recursive: true });
+  return path.join(dir, "sessions", "2026", "06", "03");
+}
+
+/**
+ * Put a foreign provider in the OpenTelemetry global registry. The registry
+ * then refuses the plugin's own registration, which is what happens when
+ * another instrumentation loads first in the hook process.
+ */
+function occupyGlobalRegistry(): unknown {
+  const previous = (globalThis as Record<symbol, unknown>)[OTEL_API_KEY];
+  const noopTracer = {
+    startSpan: () => {
+      throw new Error("span created on the foreign global provider");
+    },
+    startActiveSpan: () => {
+      throw new Error("span created on the foreign global provider");
+    },
+  };
+  (globalThis as Record<symbol, unknown>)[OTEL_API_KEY] = {
+    version: "1.9.1",
+    trace: { getTracer: () => noopTracer },
+  };
+  return previous;
+}
+
+let previousGlobal: unknown;
+
+beforeEach(() => {
+  captured.length = 0;
+  previousGlobal = occupyGlobalRegistry();
+});
+
+afterEach(() => {
+  (globalThis as Record<symbol, unknown>)[OTEL_API_KEY] = previousGlobal;
+  setLangfuseTracerProvider(null);
+});
+
+describe("setupInstrumentation", () => {
+  it("exports spans when the global registry already holds another provider", async () => {
+    const instrumentation = setupInstrumentation(baseConfig);
+    const dir = stageFixtures();
+
+    await convertRollout(path.join(dir, "rollout-basic-main.jsonl"), { config: baseConfig });
+    await instrumentation.shutdown();
+
+    const root = captured.find((s) => s.name === "Codex Turn");
+    expect(root, "the turn span never reached the plugin's span processor").toBeDefined();
+  });
+
+  it("releases the provider on shutdown", async () => {
+    const instrumentation = setupInstrumentation(baseConfig);
+    const bound = getLangfuseTracerProvider();
+
+    await instrumentation.shutdown();
+
+    expect(getLangfuseTracerProvider()).not.toBe(bound);
+  });
+});


### PR DESCRIPTION
Refs langfuse/codex-observability-plugin#51 (langfuse/codex-observability-plugin#51). This removes the failure mode the issue points at. See "Confirmation status" below

Fixes [LFE-15354](https://linear.app/clickhouse/issue/LFE-15354/stop-hook-exits-cleanly-and-reports-parsed-n-turns-but-no-trace-ever)

### Problem

`setupInstrumentation` never told Langfuse which tracer provider to use. It relied on an implicit fallback, which can refuse silently. When it refuses, the hook parses a rollout, logs `parsed N turn(s)`, flushes without error and exits 0, while no span reaches Langfuse and no request reaches the ingestion endpoint.

`startObservation` resolves its tracer via `getLangfuseTracerProvider()`, which returns an explicitly bound provider if there is one and otherwise falls back to the OpenTelemetry global registry. `registerGlobal` refuses the registration in two cases — the slot is already taken, or the API version does not match — and reports both only through the OpenTelemetry `diag` logger, which is a no-op unless configured. In either case `startObservation` gets a no-op tracer, so every span is non-recording: clean parse, clean flush, zero network traffic, zero errors.

The reliance is original: `provider.register()` has been the only wiring since the initial commit, and `setLangfuseTracerProvider` was never imported, so the bundler dropped it from `dist/index.mjs` entirely. The SDK documents the explicit pairing as the way to bind a custom provider.

### Fix

Call `setLangfuseTracerProvider(provider)` alongside `provider.register()`. `register()` is still needed: it installs the AsyncLocalStorage context manager that `propagateAttributes` relies on. Verified — dropping `register()` still exports spans, but `sessionId` and `tags` silently disappear from traces.

### Confirmation status

Reproduced end-to-end through real Codex sessions (codex-cli 0.148.0, macOS, Langfuse Cloud), with a genuine second `NodeTracerProvider` registering first inside the hook process — what an APM agent does via `NODE_OPTIONS`:

<!-- linear:table-colwidths:160,160,160,160,160 -->
| arm | bundle | registry | hook output | trace in Langfuse |
| -- | -- | -- | -- | -- |
| baseline | old | free | parsed + uploaded | arrived |
| second registrant | old | occupied | parsed + uploaded | **never arrived** |
| second registrant | new | occupied | parsed + uploaded | arrived |
| regression check | new | free | parsed + uploaded | arrived |

The second row is the issue title verbatim: the Stop hook exits cleanly, reports `parsed 1 turn(s)`, Codex shows "Stop Completed" — and the ingestion endpoint is never hit.

What is **not** established is that this was the trigger on the reporter's machine. On macOS the bug does not occur on its own: the installed bundle carries a single `@opentelemetry/api` copy, Node 20/22/24 all export correctly, and with the OTel `diag` logger enabled the registration reports success. One reported detail also does not fit this mechanism: in the induced failure the sidecar is still written, while the issue reports no sidecar. A `diag`-enabled run on the reporter's machine would settle which gate, if any, closes there.

The fix is worth landing regardless, because it removes the dependency on the registry rather than patching a symptom.

### Tests

`plugins/tracing/test/instrumentation.test.ts` occupies the global registry, runs `setupInstrumentation`, converts a fixture rollout and asserts the turn span reaches the plugin's own span processor. It fails without the fix and passes with it — verified in both directions.

A source-level assertion would not cover this: the call was previously tree-shaken out of `dist/index.mjs` because nothing imported it, so a test that only greps the source would stay green while the shipped bundle is broken.

### Note on the dist diff

`dist/index.mjs` shows \~700 changed lines. The module set is identical (340 regions before and after); the bundler only reordered them because the new import changed the module graph. The only new content is `setLangfuseTracerProvider`, previously tree-shaken out, plus its call site. `pnpm run lint:dist` passes.

### Out of scope

Two separate findings from this investigation, both worth their own issue:

1. **Windows hooks may never spawn.** `hooks/hooks.json` uses `${CODEX_HOME:-$HOME/.codex}`, POSIX parameter expansion. Measured: run through a shell it expands and exits 0; spawned as argv without a shell, Node fails in the module loader before any plugin code runs. This masks the bug above wherever hooks are spawned without a shell.
2. **A silently dropped turn is still marked uploaded.** The sidecar is written even when the export produced no request, so the turn is never retried once the tracer problem is fixed.