### PR TITLE
fix: read the user prompt from the structured item event

### DIFF
--- a/plugins/tracing/dist/index.mjs
+++ b/plugins/tracing/dist/index.mjs
@@ -46741,7 +46741,7 @@ function parseSession(lines) {
 					const s = ensureStep(ts);
 					if (text) s.text = s.text ? `${s.text}\n${text}` : text;
 				} else if (msg.role === "user" && text) {
-					if (!turn.userInputFallback && !/^<(environment_context|user_instructions)/.test(text.trim())) turn.userInputFallback = text;
+					if (!turn.userInputFallback && !/<\/?(environment_context|user_instructions)\b/.test(text) && !/^# AGENTS\.md instructions for\b/.test(text.trim())) turn.userInputFallback = text;
 				}
 			} else if (p.type === "function_call") {
 				const call = p;
@@ -46825,6 +46825,9 @@ function parseSession(lines) {
 			ensureTurn(ts);
 			if (et === "user_message" && typeof p.message === "string") {
 				if (!turn.userInput) turn.userInput = p.message;
+			} else if (et === "item_completed" && p.item?.type === "UserMessage") {
+				const text = extractMessageText(p.item.content);
+				if (text && !turn.userInput) turn.userInput = text;
 			} else if (et === "agent_message" && typeof p.message === "string") turn.lastAgentMessage = p.message;
 			else if (et === "token_count") {
 				if (p.info?.total_token_usage) turn.totalUsage = p.info.total_token_usage;

--- a/plugins/tracing/src/parse.ts
+++ b/plugins/tracing/src/parse.ts
@@ -203,11 +203,12 @@ export function parseSession(lines: RolloutLine[]): {
           const s = ensureStep(ts);
           if (text) s.text = s.text ? `${s.text}\n${text}` : text;
         } else if (msg.role === "user" && text) {
-          // Codex injects <environment_context>/<user_instructions> as user
-          // messages; keep only the first that does not look like wrapper XML.
+          // Codex concatenates injected context into user messages; the block
+          // may start with an AGENTS.md preamble, so match the elements anywhere.
           if (
             !turn!.userInputFallback &&
-            !/^<(environment_context|user_instructions)/.test(text.trim())
+            !/<\/?(environment_context|user_instructions)\b/.test(text) &&
+            !/^# AGENTS\.md instructions for\b/.test(text.trim())
           ) {
             turn!.userInputFallback = text;
           }
@@ -303,6 +304,11 @@ export function parseSession(lines: RolloutLine[]): {
 
       if (et === "user_message" && typeof p.message === "string") {
         if (!turn!.userInput) turn!.userInput = p.message;
+      } else if (et === "item_completed" && p.item?.type === "UserMessage") {
+        // The structured item carries the bare prompt; the `response_item`
+        // copy may be concatenated with injected context.
+        const text = extractMessageText(p.item.content);
+        if (text && !turn!.userInput) turn!.userInput = text;
       } else if (et === "agent_message" && typeof p.message === "string") {
         turn!.lastAgentMessage = p.message;
       } else if (et === "token_count") {

--- a/plugins/tracing/src/types.ts
+++ b/plugins/tracing/src/types.ts
@@ -129,6 +129,8 @@ export type EventMsgPayload = {
     last_token_usage?: TokenUsage;
     model_context_window?: number;
   } | null;
+  /** item_completed */
+  item?: { type?: string; content?: MessageContentPart[] } | null;
   /** collab_agent_spawn_end */
   new_thread_id?: string | null;
   /** sub_agent_activity */

--- a/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-agents-preamble-main.jsonl
+++ b/plugins/tracing/test/fixtures/sessions/2026/06/03/rollout-agents-preamble-main.jsonl
@@ -1,0 +1,7 @@
+{"timestamp": "2026-06-03T10:00:00.000Z", "type": "session_meta", "payload": {"session_id": "sess-agents-preamble", "cwd": "/repo", "cli_version": "0.149.0", "model_provider": "openai"}}
+{"timestamp": "2026-06-03T10:00:01.000Z", "type": "event_msg", "payload": {"type": "task_started", "turn_id": "turn-1"}}
+{"timestamp": "2026-06-03T10:00:02.000Z", "type": "response_item", "payload": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "# AGENTS.md instructions for /repo\n\n<INSTRUCTIONS>\n# Projektregeln\n\n- Antworte knapp.\n- Aendere keine Dateien.\n\n</INSTRUCTIONS>\n<environment_context>\n  <cwd>/repo</cwd>\n  <shell>zsh</shell>\n</environment_context>"}]}}
+{"timestamp": "2026-06-03T10:00:03.000Z", "type": "response_item", "payload": {"type": "message", "role": "user", "content": [{"type": "input_text", "text": "sag mal hallo"}]}}
+{"timestamp": "2026-06-03T10:00:04.000Z", "type": "event_msg", "payload": {"type": "item_completed", "turn_id": "turn-1", "item": {"type": "UserMessage", "content": [{"type": "text", "text": "sag mal hallo"}]}}}
+{"timestamp": "2026-06-03T10:00:05.000Z", "type": "response_item", "payload": {"type": "message", "role": "assistant", "content": [{"type": "output_text", "text": "Hallo!"}]}}
+{"timestamp": "2026-06-03T10:00:06.000Z", "type": "event_msg", "payload": {"type": "task_complete", "turn_id": "turn-1", "last_agent_message": "Hallo!"}}

--- a/plugins/tracing/test/parse.test.ts
+++ b/plugins/tracing/test/parse.test.ts
@@ -301,3 +301,39 @@ describe("parseSession", () => {
     expect(tool.output).toBe("patched");
   });
 });
+
+describe("user prompt extraction", () => {
+  it("prefers the structured UserMessage over the injected context block", () => {
+    const { turns } = parseSession(loadFixture("rollout-agents-preamble-main.jsonl"));
+
+    expect(turns).toHaveLength(1);
+    expect(turns[0]!.userInput).toBe("sag mal hallo");
+    expect(turns[0]!.userInput).not.toContain("AGENTS.md instructions");
+  });
+
+  it("keeps a prompt that merely mentions the wrapper tags", () => {
+    // Only the structured item can rescue this prompt: the fallback rejects
+    // any text containing the wrapper elements.
+    const prompt = "why does <environment_context> appear in my traces?";
+    const lines = loadFixture("rollout-agents-preamble-main.jsonl").map((line) =>
+      JSON.stringify(line).includes("sag mal hallo")
+        ? (JSON.parse(JSON.stringify(line).replaceAll("sag mal hallo", prompt)) as RolloutLine)
+        : line,
+    );
+
+    expect(parseSession(lines).turns[0]!.userInput).toBe(prompt);
+  });
+
+  it("rejects an AGENTS.md-prefixed wrapper in the fallback path", () => {
+    // Older CLIs emit no structured user item; drop it from the fixture.
+    const lines = loadFixture("rollout-agents-preamble-main.jsonl").filter(
+      (line) =>
+        !(
+          line.type === "event_msg" && (line.payload as { type?: string }).type === "item_completed"
+        ),
+    );
+    const { turns } = parseSession(lines);
+
+    expect(turns[0]!.userInput).toBe("sag mal hallo");
+  });
+});


### PR DESCRIPTION
Fixes langfuse/codex-observability-plugin#47 (langfuse/codex-observability-plugin#47).

### Problem

Both paths that resolved a turn's prompt missed on current Codex CLI versions. No `user_message` event is emitted any more, so the fallback took over — and that fallback accepted the first `user` message whose text did not *start* with a wrapper element. Codex concatenates the injected context into one message, so with an `AGENTS.md` present it starts with the AGENTS preamble, the anchored test failed, and the whole wrapper was exported as the prompt.

### Fix

* Prefer the `item_completed` event carrying a `UserMessage` item: it holds the bare prompt with no context attached.
* In the fallback, match the wrapper elements anywhere in the text (plus the AGENTS preamble), for CLI versions that emit neither structured event.

Both changes are needed independently, as the issue notes: fixing only the fallback leaves a heuristic in the hot path that has already changed shape three times (`<environment_context>`, `<recommended_plugins>`, `# AGENTS.md instructions for …`).

### Tests

Fixture built from a real 0.149 rollout. Two cases pin the structured path (including a prompt that merely *mentions* a wrapper tag, which the fallback must not rescue), one pins the fallback with the structured event removed. Verified failing without each half of the fix.

Also verified end to end against a local Langfuse instance: with an `AGENTS.md` in the working directory, the trace input is now the prompt (34 chars) instead of a 1177-char wrapper.

### Known gap

A CLI that emits neither structured event *and* a prompt that mentions a wrapper tag still yields an empty input. No known version behaves that way — 0.147+ emits `item_completed`, older versions emitted `user_message`.