### PR TITLE
chore: add npm package manifest for the tracing plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
-  "name": "@langfuse/codex-observability-plugin",
+  "name": "codex-observability-plugin-workspace",
   "version": "0.1.0",
+  "private": true,
   "description": "OpenAI Codex plugin that traces agent turns, tool calls, and subagents to Langfuse",
   "keywords": [
     "codex",

--- a/plugins/tracing/package.json
+++ b/plugins/tracing/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@langfuse/codex-observability-plugin",
+  "version": "0.1.0",
+  "description": "Langfuse observability plugin for the OpenAI Codex coding agent for tracing prompts, agent turns, model generations, and tool calls.",
+  "license": "MIT",
+  "author": "Langfuse",
+  "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/langfuse/codex-observability-plugin.git",
+    "directory": "plugins/tracing"
+  },
+  "bugs": {
+    "url": "https://github.com/langfuse/codex-observability-plugin/issues"
+  },
+  "homepage": "https://github.com/langfuse/codex-observability-plugin#readme",
+  "keywords": [
+    "codex",
+    "codex-plugin",
+    "langfuse",
+    "openai",
+    "observability",
+    "tracing",
+    "opentelemetry"
+  ],
+  "files": [
+    ".codex-plugin",
+    "hooks",
+    "dist"
+  ],
+  "scripts": {
+    "prepack": "pnpm -w run build"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}


### PR DESCRIPTION
Refs LFE-15729. Step 1 of moving this plugin to npm distribution. **No user-facing change in this PR.**

### Why

Codex has supported npm plugin sources since codex-cli **0.143.0** (2026-07-08), so the plugin no longer has to be delivered as a bundle committed to git. Moving to npm resolves several current problems, but this PR only lays the groundwork for it.

### What this PR does

Adds `plugins/tracing/package.json` so the plugin directory is a publishable npm package, and makes the repo root a private workspace root.

- `plugins/tracing/package.json` (new): `@langfuse/codex-observability-plugin`, version kept in sync with `.codex-plugin/plugin.json`, `files: [".codex-plugin", "hooks", "dist"]`, and a `prepack` build so a stale bundle cannot be published. **No dependencies** — `dist/index.mjs` is a self-contained bundle, because Codex never installs a plugin's dependencies.
- `package.json` (root): `private: true` and renamed to `codex-observability-plugin-workspace`. The publishable name had to move to `plugins/tracing`, since Codex expects `.codex-plugin/plugin.json` at the package root, and two packages in one workspace cannot share a name. The root keeps all dependencies and scripts for building and testing.


### Verified

Package built and installed end to end without publishing, using a local HTTPS mock registry and an isolated `CODEX_HOME` (codex-cli 0.149.0, npm 11.13.0, node 24.16.0):

| Check | Result |
| -- | -- |
| `npm pack --ignore-scripts` | 4 files, 268 KB, `.codex-plugin/plugin.json` included, no `src`/`test` |
| `codex plugin add` from an npm-source marketplace | installs successfully |
| installed plugin cache | 4 files (vs 24 today), no `node_modules` |
| Stop hook run from that cache | `parsed 1 turn(s)`, `POST /api/public/otel/v1/traces`, 5,173 B |
| `prepack` on a real `npm pack` | builds the bundle, output byte-identical |
| `pnpm run lint`, `pnpm test` | pass, 40/40 |

At version `0.1.0` the npm cache path is identical to the path currently hard-coded in `hooks.json`, so the hook command string does not change and no hook re-trust is needed.
