### PR TITLE
chore: add npm release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,62 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Stage npm package and create GitHub release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - name: Validate release version
+        run: |
+          package_version="$(node -p "require('./plugins/tracing/package.json').version")"
+          manifest_version="$(node -p "require('./plugins/tracing/.codex-plugin/plugin.json').version")"
+          if [[ "$GITHUB_REF_NAME" != "v$package_version" ]]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json version $package_version" >&2
+            exit 1
+          fi
+          if [[ "$manifest_version" != "$package_version" ]]; then
+            echo "plugin.json version $manifest_version does not match package.json version $package_version" >&2
+            exit 1
+          fi
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v5
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Typecheck
+        run: pnpm run typecheck
+      - name: Stage npm package
+        run: |
+          if [[ "$GITHUB_REF_NAME" == *-* ]]; then
+            pnpm exec npm stage publish --provenance --access public --tag next
+          else
+            pnpm exec npm stage publish --provenance --access public
+          fi
+      - name: Create draft GitHub release
+        run: gh release create "$GITHUB_REF_NAME" --draft --generate-notes --verify-tag
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,12 @@ jobs:
           package-manager-cache: false
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Typecheck
-        run: pnpm run typecheck
+      - name: Lint
+        run: pnpm run lint
+      - name: Test
+        run: pnpm test
       - name: Stage npm package
+        working-directory: plugins/tracing
         run: |
           if [[ "$GITHUB_REF_NAME" == *-* ]]; then
             pnpm exec npm stage publish --provenance --access public --tag next

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.10.0",
+    "npm": "11.15.0",
     "prettier": "^3.9.4",
     "tsdown": "^0.18.0",
     "typescript": "^5.7.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ importers:
       '@types/node':
         specifier: ^22.10.0
         version: 22.19.19
+      npm:
+        specifier: 11.15.0
+        version: 11.15.0
       prettier:
         specifier: ^3.9.4
         version: 3.9.4
@@ -737,6 +740,77 @@ packages:
     resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  npm@11.15.0:
+    resolution: {integrity: sha512-+k0tk7lRnpMUPnC7kTuU/yrV/mnFoPhJQ75VfLtZ6fwbzOVXaPsTE/Il9Pn1DHi482byMyqkHv/XsQ76mNjXLw==}
+    engines: {node: ^20.17.0 || >=22.9.0}
+    hasBin: true
+    bundledDependencies:
+      - '@isaacs/string-locale-compare'
+      - '@npmcli/arborist'
+      - '@npmcli/config'
+      - '@npmcli/fs'
+      - '@npmcli/map-workspaces'
+      - '@npmcli/metavuln-calculator'
+      - '@npmcli/package-json'
+      - '@npmcli/promise-spawn'
+      - '@npmcli/redact'
+      - '@npmcli/run-script'
+      - '@sigstore/tuf'
+      - abbrev
+      - archy
+      - cacache
+      - chalk
+      - ci-info
+      - fastest-levenshtein
+      - fs-minipass
+      - glob
+      - graceful-fs
+      - hosted-git-info
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-even-better-errors
+      - libnpmaccess
+      - libnpmdiff
+      - libnpmexec
+      - libnpmfund
+      - libnpmorg
+      - libnpmpack
+      - libnpmpublish
+      - libnpmsearch
+      - libnpmteam
+      - libnpmversion
+      - make-fetch-happen
+      - minimatch
+      - minipass
+      - minipass-pipeline
+      - ms
+      - node-gyp
+      - nopt
+      - npm-audit-report
+      - npm-install-checks
+      - npm-package-arg
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - p-map
+      - pacote
+      - parse-conflict-json
+      - proc-log
+      - qrcode-terminal
+      - read
+      - semver
+      - spdx-expression-parse
+      - ssri
+      - supports-color
+      - tar
+      - text-table
+      - tiny-relative-date
+      - treeverse
+      - validate-npm-package-name
+      - which
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -1512,6 +1586,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   nanoid@3.3.15: {}
+
+  npm@11.15.0: {}
 
   obug@2.1.1: {}
 


### PR DESCRIPTION
Refs LFE-15729. Step 2 of moving this plugin to npm distribution.

> [!IMPORTANT]
> **Draft, stacked on #62.** This branch contains #62's commit, so the diff below also shows `plugins/tracing/package.json` until that PR merges. 

### Why

#62 makes the plugin a publishable npm package. This adds the release automation, modelled on the in-house precedent in [`langfuse/pi-observability-plugin`](https://github.com/langfuse/pi-observability-plugin/blob/main/.github/workflows/release.yml).

### What this PR does

- **`.github/workflows/release.yml`** (new): tag-triggered on `v*`, validates versions, installs, lints, tests, stages the package on npm with provenance, then creates a draft GitHub release. Prerelease tags (`v0.2.0-rc.1`) go out under the `next` dist-tag.
- **`package.json`**: adds `npm: 11.15.0` as a devDependency. `npm stage publish` does not exist in npm 10.9.8, which is what Node 22 bundles, so `pnpm exec npm` needs a pinned newer npm. Same approach pi uses.

### Verified locally

Each workflow step run by hand (codex-cli 0.149.0, npm 11.15.0, node 24.16.0):

| Check | Result |
| -- | -- |
| `actionlint` on `release.yml` | no findings |
| version validation (the exact `node -p` commands) | `package.json` 0.1.0 == `plugin.json` 0.1.0 |
| `pnpm install --frozen-lockfile` | pass |
| `pnpm run lint` | pass |
| `pnpm test` | 40/40 |
| staging step as `npm publish --dry-run` from `plugins/tracing` | `prepack` builds, `@langfuse/codex-observability-plugin@0.1.0`, 4 files |
| `pnpm exec npm --version` in that step | 11.15.0, `stage` subcommand available |
| prerelease branch logic | `v0.1.0`/`v0.2.0` → `latest`, `v0.2.0-rc.1`/`v1.0.0-beta.2` → `next` |

### Not verified, and one thing a maintainer has to do

**The workflow has never actually run.** It only triggers on a `v*` tag, and a test run would stage a real package on npm. The YAML and every step were checked individually; the end-to-end run is open until the first real tag.

**Before the first release, a maintainer of the `@langfuse` npm scope has to configure npm trusted publishing (OIDC)** for `@langfuse/codex-observability-plugin`, with this repository and `release.yml` as the trusted publisher. Without that, the first run fails at authentication. I do not have access to do this.

### Release flow this enables

1. Bump the version in **both** `plugins/tracing/package.json` and `plugins/tracing/.codex-plugin/plugin.json`, rebuild the bundle (`pnpm run build`), commit.
2. Tag `v<version>` and push the tag.
3. The workflow validates, tests, stages on npm, and opens a draft GitHub release.
4. `npm stage list @langfuse/codex-observability-plugin`, then `npm stage approve <stage-id>` (requires npm 2FA). Or `npm stage reject`.
5. Publish the draft GitHub release.

### Related

- #62 — the package manifest this depends on
- #61 — switches the hook command to `${PLUGIN_ROOT}`. Needed before the **first version bump**: the current hard-coded `tracing/0.1.0` cache path breaks on any other version. Verified locally. Not touched here to avoid duplicating that PR.
