### PR TITLE
fix: use ${PLUGIN_ROOT} so the Stop hook runs on Windows

### DIFF
--- a/plugins/tracing/hooks/hooks.json
+++ b/plugins/tracing/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CODEX_HOME:-$HOME/.codex}/plugins/cache/codex-observability-plugin/tracing/0.1.0/dist/index.mjs\"",
+            "command": "node \"${PLUGIN_ROOT}/dist/index.mjs\"",
             "timeout": 30,
             "statusMessage": "Uploading Codex trace to Langfuse"
           }

--- a/plugins/tracing/test/hook-command.test.ts
+++ b/plugins/tracing/test/hook-command.test.ts
@@ -8,8 +8,7 @@ import { afterEach, describe, expect, it } from "vitest";
 
 const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
 const hookConfigFile = path.join(repoRoot, "plugins/tracing/hooks/hooks.json");
-const bundleFile = path.join(repoRoot, "plugins/tracing/dist/index.mjs");
-const pluginManifestFile = path.join(repoRoot, "plugins/tracing/.codex-plugin/plugin.json");
+const pluginRootDir = path.join(repoRoot, "plugins/tracing");
 
 const tmpDirs: string[] = [];
 
@@ -24,20 +23,6 @@ function readHookCommand(): string {
     hooks: { Stop: Array<{ hooks: Array<{ command: string }> }> };
   };
   return config.hooks.Stop[0].hooks[0].command;
-}
-
-function readPluginVersion(): string {
-  const manifest = JSON.parse(fs.readFileSync(pluginManifestFile, "utf-8")) as { version: string };
-  return manifest.version;
-}
-
-function stageInstalledPlugin(codexHome: string): void {
-  const installedBundle = path.join(
-    codexHome,
-    "plugins/cache/codex-observability-plugin/tracing/0.1.0/dist/index.mjs",
-  );
-  fs.mkdirSync(path.dirname(installedBundle), { recursive: true });
-  fs.copyFileSync(bundleFile, installedBundle);
 }
 
 function runShellCommand(
@@ -81,15 +66,15 @@ afterEach(() => {
 });
 
 describe("bundled Stop hook command", () => {
-  it("runs from an arbitrary session cwd via CODEX_HOME instead of a relative repo path", async () => {
+  it("runs from an arbitrary session cwd via PLUGIN_ROOT instead of a relative repo path", async () => {
     const codexHome = makeTempDir("lf-codex-home-");
     const sessionCwd = makeTempDir("lf-codex-cwd-");
-    stageInstalledPlugin(codexHome);
 
     const { code, stderr, stdout } = await runShellCommand(readHookCommand(), {
       cwd: sessionCwd,
       env: {
         ...process.env,
+        PLUGIN_ROOT: pluginRootDir,
         CODEX_HOME: codexHome,
         HOME: codexHome,
       },
@@ -108,9 +93,7 @@ describe("bundled Stop hook command", () => {
     expect(readHookCommand()).not.toContain("./plugins/tracing/dist/index.mjs");
   });
 
-  it("points at the installed cache path for this plugin version", () => {
-    expect(readHookCommand()).toContain(
-      `/plugins/cache/codex-observability-plugin/tracing/${readPluginVersion()}/dist/index.mjs`,
-    );
+  it("uses no shell syntax beyond the placeholder Codex substitutes itself", () => {
+    expect(readHookCommand().replaceAll("${PLUGIN_ROOT}", "")).not.toContain("$");
   });
 });


### PR DESCRIPTION
## Problem

Codex runs command hooks through the platform shell: `$SHELL -lc` on Unix, but `%COMSPEC% /C`, i.e. `cmd.exe`, on Windows (`codex-rs/hooks/src/engine/command_runner.rs`). `cmd.exe` has no POSIX parameter expansion, so the `Stop` hook command

```
node "${CODEX_HOME:-$HOME/.codex}/plugins/cache/codex-observability-plugin/tracing/0.1.0/dist/index.mjs"
```

reached `node` as a literal string, and the hook always exited 1 on Windows.

## Fix

```
node "${PLUGIN_ROOT}/dist/index.mjs"
```

Codex substitutes `${PLUGIN_ROOT}` in a plugin hook's command line itself, literally and on every platform, before any shell sees the line (openai/codex#19705, `codex-rs/hooks/src/engine/discovery.rs`). That support shipped on 2026-04-28, so it predates every Codex version in the reports (0.135.0 and newer). It also drops the hardcoded `0.1.0`, so the path no longer has to be bumped in lockstep with the plugin version.

## Why the test file changes too

The existing test could not have caught this, and it also blocked those two PRs:

- it spawned the command with `shell: true`, so it always got a POSIX shell, and CI is `ubuntu-latest` only
- it set `CODEX_HOME` but never `PLUGIN_ROOT`, so `${PLUGIN_ROOT}` expanded to the empty string and the executing test exited 1
- it asserted the version-pinned cache path, which this fix removes

Net effect is a smaller test file. `stageInstalledPlugin` and `readPluginVersion` existed only to serve the old hardcoded path, and the staged `plugins/cache/.../0.1.0/` tree existed only so that path had something to find. The test now points `PLUGIN_ROOT` at the real plugin directory and executes the committed bundle.

The one genuinely new assertion is the regression guard:

```ts
expect(readHookCommand().replaceAll("${PLUGIN_ROOT}", "")).not.toContain("$");
```

`${PLUGIN_ROOT}` is resolved by Codex. Any other `$` can only be resolved by a shell, and on Windows that shell is `cmd.exe`. This is the only assertion that separates "works on Linux" from "works on Windows", which matters because CI never runs Windows.

## Verification

- `pnpm test` 40/40 green, `pnpm run lint` clean
- reverting `hooks.json` alone fails 2 of the 3 tests on Linux
- a command that works on Linux but breaks on Windows, `"${NODE_BINARY:-node}" "${PLUGIN_ROOT}/dist/index.mjs"`, fails the guard alone while the executing test stays green

Fixes #55
Fixes #32

LFE-15599